### PR TITLE
fix crash when no user credentials exist

### DIFF
--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -22,7 +22,7 @@ module Pod
       end
 
       def token
-        netrc['trunk.cocoapods.org'].last
+        netrc['trunk.cocoapods.org'] && netrc['trunk.cocoapods.org'].last
       end
 
       class Register < Trunk


### PR DESCRIPTION
## Before

`~/s/r/cocoapods-trunk (master=) pod trunk me`
### Stack

```
   CocoaPods : 0.28.0
        Ruby : ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin13.0.0]
    RubyGems : 2.0.6
        Host : Mac OS X 10.9.2 (13C32)
       Xcode : 5.0.2 (5A3005)
Ruby lib dir : /Users/orta/.rvm/rubies/ruby-2.0.0-p247/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ c02cc41137c4f46cd8bbf0ef93511b687da02c5e
```
### Error

```
NoMethodError - undefined method `last' for nil:NilClass
/Users/orta/spiel/ruby/cocoapods-trunk/lib/pod/command/trunk.rb:25:in `token'
/Users/orta/spiel/ruby/cocoapods-trunk/lib/pod/command/trunk.rb:61:in `validate!'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/claide-0.4.0/lib/claide/command.rb:212:in `run'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/cocoapods-0.28.0/lib/cocoapods/command.rb:52:in `run'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/gems/cocoapods-0.28.0/bin/pod:24:in `<top (required)>'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/pod:23:in `load'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/pod:23:in `<main>'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `eval'
/Users/orta/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `<main>'
```
## After

```
~/s/r/cocoapods-trunk (master ⚡=) pod trunk me
[!] You need to register a session first.
```
