### PR TITLE
Change quote character in "owner's"

### DIFF
--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -79,7 +79,7 @@ module Pod
         def validate!
           super
           help! 'You need to register a session first.' unless netrc['trunk.cocoapods.org']
-          help! 'Specify the pod name and the new owner’s email address' unless @pod && @email
+          help! "Specify the pod name and the new owner's email address" unless @pod && @email
         end
 
         def run


### PR DESCRIPTION
The old version seems to cause a SyntaxError "invalid multibyte char" sometimes.
