### PR TITLE
Add encoding: UTF-8

### DIFF
--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'json'
 require 'rest'
 require 'netrc'


### PR DESCRIPTION
Fixes SyntaxError "invalid multibyte char" caused by quote character.
