### PR TITLE
Feature Request #3275: Prevent private podspecs from being pushed to trunk.

### DIFF
--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -99,9 +99,10 @@ module Pod
 
         # Performs a full lint against the podspecs.
         #
-        # TODO: Currently copied verbatim from `pod push`.
         def validate_podspec
           UI.puts 'Validating podspec'.yellow
+
+          raise Informative, 'The podspec is private.' if spec.private_spec?
 
           validator = Validator.new(spec, %w(https://github.com/CocoaPods/Specs.git))
           validator.allow_warnings = @allow_warnings

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -110,6 +110,12 @@ module Pod
         cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec --use-libraries))
         cmd.send(:validate_podspec)
       end
+
+      it 'should error when the spec is private' do
+        cmd = Command.parse(%w(trunk push spec/fixtures/PrivateBananaLib.podspec))
+        exception = lambda { cmd.send(:validate_podspec) }.should.raise Informative
+        exception.message.should.include 'The podspec is private'
+      end
     end
   end
 end

--- a/spec/fixtures/PrivateBananaLib.podspec
+++ b/spec/fixtures/PrivateBananaLib.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = 'PrivateBananaLib'
+  s.version      = '1.0'
+  s.authors      = 'Banana Corp', { 'Monkey Boy' => 'monkey@banana-corp.local' }
+  s.homepage     = 'http://banana-corp.local/banana-lib.html'
+  s.summary      = 'Chunky bananas!'
+  s.description  = 'Full of chunky bananas.'
+  s.source       = { :git => 'http://banana-corp.local/banana-lib.git', :tag => 'v1.0' }
+  s.license      = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...'
+  }
+  s.source_files        = 'Classes/*.{h,m,d}', 'Vendor'
+  s.resources           = "Resources/*"
+  s.vendored_framework  = 'PrivateBananalib.framework'
+  s.vendored_library    = 'libBananalib.a'
+  s.preserve_paths      = 'preserve_me.txt'
+  s.public_header_files = 'Classes/Banana.h'
+  s.private_spec        = true
+
+  s.prefix_header_file = 'Classes/BananaLib.pch'
+  s.xcconfig     = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
+
+end


### PR DESCRIPTION
This is the second of two parts for [#3275](https://github.com/CocoaPods/CocoaPods/issues/3275), which uses spec changes introduced [here](https://github.com/CocoaPods/Core/pull/228). The build will be red until that is merged. :rainbow: 

cc: @orta 