### PR TITLE
No longer update master spec repository when unnecessary during push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Master
+
+##### Enhancements
+
+* `pod trunk push` will no longer update the spec repository before
+  linting your specification if you have no dependencies.  
+  [Kyle Fuller](https://github.com/kylef)
+
+
 ## 0.6.4 (2015-08-28)
 
 ##### Bug Fixes

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -55,7 +55,7 @@ module Pod
         end
 
         def run
-          update_master_repo
+          update_master_repo unless spec.dependencies.empty?
           validate_podspec
           response = request_path(:post, "pods?allow_warnings=#{@allow_warnings}",
                                   spec.to_json, auth_headers)


### PR DESCRIPTION
When there are no dependencies, there is no need to update the spec repository during a push. This is a small optimisation due to the fact my internet is beyond terrible and it noticeably slows down pushing specs for 95% of the cases when a specification doesn't have any dependencies.