### PR TITLE
Add error handling around accessing the .netrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Improve handling of users not having access to their netrc file.  
+  [Orta Therox](https://github.com/orta)
+  [CocoaPods#5411](https://github.com/CocoaPods/CocoaPods/issues/5411)
 
 ## 1.0.0 (2016-05-10)
 

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -87,12 +87,17 @@ module Pod
       end
 
       def netrc
-        @@netrc ||= Netrc.read
+        begin
+          @@netrc ||= Netrc.read
+        rescue Errno::ENOENT => e
+          UI.warn 'CocoaPods could not access your ~/.netrc file, '\
+                  'please ensure you have read access to it.'
+        end
       end
 
       def token
-        ENV['COCOAPODS_TRUNK_TOKEN'] ||
-          (netrc['trunk.cocoapods.org'] && netrc['trunk.cocoapods.org'].password)
+          ENV['COCOAPODS_TRUNK_TOKEN'] ||
+            (netrc['trunk.cocoapods.org'] && netrc['trunk.cocoapods.org'].password)
       end
 
       def default_headers


### PR DESCRIPTION
Fixes: https://github.com/CocoaPods/CocoaPods/issues/5411