### PR TITLE
Pretty Success Message when pod pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Enhancements
 
-* None.  
+* Prettier success message when successfully pushed a new version
+  [Marin](https://github.com/icanzilb)
+  [#76](https://github.com/CocoaPods/cocoapods-trunk/pull/76)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Master
+
+##### Enhancements
+
+* None.  
+
+##### Bug Fixes
+
+* None.  
+
+
 ## 1.1.0.beta.1 (2016-10-10)
 
 ##### Enhancements

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -71,20 +71,20 @@ module Pod
       end
 
       def print_messages(data_url, messages, spec = nil, action = nil)
-	    if verbose? || spec == nil
-	      # Using UI.labeled here is dangerous, as it wraps the URL and indents
-	      # it, which breaks the URL when you try to copy-paste it.
-	      UI.puts "  - Data URL: #{data_url}"
-	
-	      messages = messages.map do |entry|
-	        at, message = entry.to_a.flatten
-	        "#{formatted_time(at)}: #{message}"
-	      end
-	      UI.labeled 'Log messages', messages
-		else
+        if verbose? || spec == nil
+          # Using UI.labeled here is dangerous, as it wraps the URL and indents
+          # it, which breaks the URL when you try to copy-paste it.
+          UI.puts "  - Data URL: #{data_url}"
+
+          messages = messages.map do |entry|
+            at, message = entry.to_a.flatten
+            "#{formatted_time(at)}: #{message}"
+          end
+          UI.labeled 'Log messages', messages
+        else
           UI.puts 
           UI.puts '-' * 80
-		  UI.puts " 🎉  Congrats"
+          UI.puts " 🎉  Congrats"
           UI.puts ""
           UI.puts " 🚀  #{spec.name} (#{spec.version.to_s}) successfully #{action}"
           if messages.count > 0
@@ -94,7 +94,7 @@ module Pod
           UI.puts " 🌎  https://cocoapods.org/pods/#{spec.name}"
           UI.puts " 👍  Tell your friends!"
           UI.puts '-' * 80 
-		end
+        end
       end
       
       def json(response)

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -71,7 +71,7 @@ module Pod
       end
 
       def print_messages(data_url, messages, spec = nil, action = nil)
-        if verbose? || nil?(spec)
+        if verbose? || spec.nil?
           # Using UI.labeled here is dangerous, as it wraps the URL and indents
           # it, which breaks the URL when you try to copy-paste it.
           UI.puts "  - Data URL: #{data_url}"
@@ -82,18 +82,19 @@ module Pod
           end
           UI.labeled 'Log messages', messages
         else
+          separator = '-' * 80
           UI.puts
-          UI.puts '-' * 80
+          UI.puts separator
           UI.puts " 🎉  Congrats"
           UI.puts
           UI.puts " 🚀  #{spec.name} (#{spec.version}) successfully #{action}"
-          if messages.count > 0
-            at = messages[0].to_a.flatten[0]
+          if !messages.empty?
+            at = messages.first.to_a.flatten.first
             UI.puts " 📅  #{formatted_time(at)}"
           end
           UI.puts " 🌎  https://cocoapods.org/pods/#{spec.name}"
           UI.puts " 👍  Tell your friends!"
-          UI.puts '-' * 80
+          UI.puts separator
         end
       end
 

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -71,7 +71,7 @@ module Pod
       end
 
       def print_messages(data_url, messages, spec = nil, action = nil)
-        if verbose? || spec == nil
+        if verbose? || nil?(spec)
           # Using UI.labeled here is dangerous, as it wraps the URL and indents
           # it, which breaks the URL when you try to copy-paste it.
           UI.puts "  - Data URL: #{data_url}"
@@ -82,21 +82,21 @@ module Pod
           end
           UI.labeled 'Log messages', messages
         else
-          UI.puts 
+          UI.puts
           UI.puts '-' * 80
           UI.puts " 🎉  Congrats"
-          UI.puts ""
-          UI.puts " 🚀  #{spec.name} (#{spec.version.to_s}) successfully #{action}"
+          UI.puts
+          UI.puts " 🚀  #{spec.name} (#{spec.version}) successfully #{action}"
           if messages.count > 0
             at = messages[0].to_a.flatten[0]
             UI.puts " 📅  #{formatted_time(at)}"
           end
           UI.puts " 🌎  https://cocoapods.org/pods/#{spec.name}"
           UI.puts " 👍  Tell your friends!"
-          UI.puts '-' * 80 
+          UI.puts '-' * 80
         end
       end
-      
+
       def json(response)
         JSON.parse(response.body)
       end

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -70,18 +70,33 @@ module Pod
         raise Informative, error
       end
 
-      def print_messages(data_url, messages)
-        # Using UI.labeled here is dangerous, as it wraps the URL and indents
-        # it, which breaks the URL when you try to copy-paste it.
-        UI.puts "  - Data URL: #{data_url}"
-
-        messages = messages.map do |entry|
-          at, message = entry.to_a.flatten
-          "#{formatted_time(at)}: #{message}"
-        end
-        UI.labeled 'Log messages', messages
+      def print_messages(data_url, messages, spec = nil, action = nil)
+	    if verbose? || spec == nil
+	      # Using UI.labeled here is dangerous, as it wraps the URL and indents
+	      # it, which breaks the URL when you try to copy-paste it.
+	      UI.puts "  - Data URL: #{data_url}"
+	
+	      messages = messages.map do |entry|
+	        at, message = entry.to_a.flatten
+	        "#{formatted_time(at)}: #{message}"
+	      end
+	      UI.labeled 'Log messages', messages
+		else
+          UI.puts 
+          UI.puts '-' * 80
+		  UI.puts " 🎉  Congrats"
+          UI.puts ""
+          UI.puts " 🚀  #{spec.name} (#{spec.version.to_s}) successfully #{action}"
+          if messages.count > 0
+            at = messages[0].to_a.flatten[0]
+            UI.puts " 📅  #{formatted_time(at)}"
+          end
+          UI.puts " 🌎  http://cocoapods.org/pods/#{spec.name}"
+          UI.puts " 👍  Tell your friends!"
+          UI.puts '-' * 80 
+		end
       end
-
+      
       def json(response)
         JSON.parse(response.body)
       end

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -91,7 +91,7 @@ module Pod
             at = messages[0].to_a.flatten[0]
             UI.puts " 📅  #{formatted_time(at)}"
           end
-          UI.puts " 🌎  http://cocoapods.org/pods/#{spec.name}"
+          UI.puts " 🌎  https://cocoapods.org/pods/#{spec.name}"
           UI.puts " 👍  Tell your friends!"
           UI.puts '-' * 80 
 		end

--- a/lib/pod/command/trunk/delete.rb
+++ b/lib/pod/command/trunk/delete.rb
@@ -34,7 +34,7 @@ module Pod
         def run
           return unless confirm_deletion?
           json = delete
-          print_messages(json['data_url'], json['messages'])
+          print_messages(json['data_url'], json['messages'], nil, nil)
         end
 
         private

--- a/lib/pod/command/trunk/deprecate.rb
+++ b/lib/pod/command/trunk/deprecate.rb
@@ -28,7 +28,7 @@ module Pod
 
         def run
           json = deprecate
-          print_messages(json['data_url'], json['messages'])
+          print_messages(json['data_url'], json['messages'], nil, nil)
         end
 
         def deprecate

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -64,11 +64,11 @@ module Pod
           validate_podspec
           json = push_to_trunk
           update_master_repo
-          
+
           if (400...600).cover?(@push_status)
             print_messages(json['data_url'], nil, nil)
           else
-            print_messages(json['data_url'], json['messages'], spec(), 'published')
+            print_messages(json['data_url'], json['messages'], spec, 'published')
           end
         end
 

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -64,7 +64,12 @@ module Pod
           validate_podspec
           json = push_to_trunk
           update_master_repo
-          print_messages(json['data_url'], json['messages'], spec(), 'published')
+          
+	      if (400...600).cover?(@push_status)
+            print_messages(json['data_url'], nil, nil)
+          else
+            print_messages(json['data_url'], json['messages'], spec(), 'published')
+          end
         end
 
         private
@@ -72,6 +77,7 @@ module Pod
         def push_to_trunk
           response = request_path(:post, "pods?allow_warnings=#{@allow_warnings}",
                                   spec.to_json, auth_headers)
+          @push_status = response.status_code
           url = response.headers['location'].first
           json(request_url(:get, url, default_headers))
         rescue REST::Error => e

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -62,10 +62,10 @@ module Pod
         def run
           update_master_repo
           validate_podspec
-          json = push_to_trunk
+          status, json = push_to_trunk
           update_master_repo
 
-          if (400...600).cover?(@push_status)
+          if (400...600).cover?(status)
             print_messages(json['data_url'], nil, nil)
           else
             print_messages(json['data_url'], json['messages'], spec, 'published')
@@ -77,9 +77,8 @@ module Pod
         def push_to_trunk
           response = request_path(:post, "pods?allow_warnings=#{@allow_warnings}",
                                   spec.to_json, auth_headers)
-          @push_status = response.status_code
           url = response.headers['location'].first
-          json(request_url(:get, url, default_headers))
+          return response.status_code, json(request_url(:get, url, default_headers))
         rescue REST::Error => e
           raise Informative, 'There was an error pushing a new version ' \
                                    "to trunk: #{e.message}"

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -64,7 +64,7 @@ module Pod
           validate_podspec
           json = push_to_trunk
           update_master_repo
-          print_messages(json['data_url'], json['messages'])
+          print_messages(json['data_url'], json['messages'], spec(), 'published')
         end
 
         private

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -65,7 +65,7 @@ module Pod
           json = push_to_trunk
           update_master_repo
           
-	      if (400...600).cover?(@push_status)
+          if (400...600).cover?(@push_status)
             print_messages(json['data_url'], nil, nil)
           else
             print_messages(json['data_url'], json['messages'], spec(), 'published')


### PR DESCRIPTION
Adding pretty output when pushed successfully and not in verbose mode:

![image](https://cloud.githubusercontent.com/assets/633862/19385774/ddc1dca8-9210-11e6-96fb-90211225e378.png)

is it safe to assume there's always at least one message? I'm actually just using it to get the date at trunk.rb: 91 ... now that I think about it - maybe just take the current date and print it in the console? 

Feelings?