### PR TITLE
Include the swift version when sending to trunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ addons:
    repo_token: 937468c2cbb0d7c0546b62d0fcbcba8a2a8b82714a64a52ffd0b951e71df626d
 
 before_install:
-  - echo "gem: -n/usr/local/bin" >> ~/.gemrc
+  - export GEM_HOME=$HOME/.gem
+  - export PATH=$GEM_HOME/bin:$PATH
   - sudo gem install bundler
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Enhancements
 
-* None.  
+* Passes the version from `--swift-version` to CocoaPods Trunk  
+  [Orta](https://github.com/orta)
+  [#92](https://github.com/CocoaPods/cocoapods-trunk/pull/72)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Master
+
+##### Enhancements
+
+* None.  
+
+##### Bug Fixes
+
+* None.  
+
+
 ## 1.1.0.beta.1 (2016-10-10)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Passes the version of Swift used for dpeloyment to the CocoaPods Specs repo  
   [Orta](https://github.com/orta)
   [#92](https://github.com/CocoaPods/cocoapods-trunk/pull/72)
+
 * Prettier success message when successfully pushed a new version
   [Marin](https://github.com/icanzilb)
   [#76](https://github.com/CocoaPods/cocoapods-trunk/pull/76)

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -70,6 +70,7 @@ module Pod
         private
 
         def push_to_trunk
+          spec.attributes_hash[:pushed_with_swift_version] = @swift_version
           response = request_path(:post, "pods?allow_warnings=#{@allow_warnings}",
                                   spec.to_json, auth_headers)
           url = response.headers['location'].first

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -123,7 +123,7 @@ module Pod
 
           # Let the validator's logic for the swift version
           # set the value for the trunk JSON uploader
-          @swift_version = validator.swift_version
+          @swift_version = validator.used_swift_version
         end
 
         def update_master_repo

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -115,6 +115,10 @@ module Pod
           unless validator.validated?
             raise Informative, "The spec did not pass validation, due to #{validator.failure_reason}."
           end
+
+          # Let the validator's logic for the swift version
+          # set the value for the trunk JSON uploader
+          @swift_version = validator.swift_version
         end
 
         def update_master_repo

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -149,6 +149,30 @@ module Pod
       end
     end
 
+    describe 'sending the swift version up to trunk' do
+      it 'passes the value to trunk' do
+        Command::Trunk::Push.any_instance.unstub(:update_master_repo)
+        Pod::Command::Trunk.any_instance.expects(:json).returns({})
+
+        Pod::Command::Trunk.any_instance.expects(:auth_headers).returns({})
+
+        response = mock
+        response.expects(:headers).returns('location' => ['http://theinternet.com'])
+
+        cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec --swift-version=1.1.2))
+
+        example = Pod::Specification.from_file('spec/fixtures/BananaLib.podspec')
+        example.attributes_hash[:pushed_with_swift_version] = '1.1.2'
+
+        cmd.stubs(:validate_podspec)
+        cmd.stubs(:request_url)
+
+        api_route = 'pods?allow_warnings=false'
+        cmd.expects(:request_path).with(:post, api_route, example.to_json, {}).returns(response)
+        cmd.send(:push_to_trunk)
+      end
+    end
+
     describe 'updating the master repo' do
       before do
         @cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec))

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -112,6 +112,7 @@ module Pod
         Validator.any_instance.stubs(:install_pod)
         Validator.any_instance.stubs(:build_pod)
         Validator.any_instance.stubs(:add_app_project_import)
+        Validator.any_instance.stubs(:used_swift_version).returns(nil)
         %i(prepare resolve_dependencies download_dependencies).each do |m|
           Installer.any_instance.stubs(m)
         end
@@ -125,7 +126,7 @@ module Pod
       end
 
       it 'passes a swift version back to command, to handle .swift-version files' do
-        Validator.any_instance.stubs(:swift_version).returns('1.2.3')
+        Validator.any_instance.stubs(:used_swift_version).returns('1.2.3')
 
         cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec))
         cmd.send(:validate_podspec)

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -124,6 +124,14 @@ module Pod
         cmd.send(:validate_podspec)
       end
 
+      it 'passes a swift version back to command, to handle .swift-version files' do
+        Validator.any_instance.stubs(:swift_version).returns('1.2.3')
+
+        cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec))
+        cmd.send(:validate_podspec)
+        cmd.instance_variable_get(:@swift_version).should == '1.2.3'
+      end
+
       it 'validates specs as frameworks by default' do
         Validator.any_instance.expects(:podfile_from_spec).
           with(:ios, '8.0', true).once.returns(Podfile.new)
@@ -164,25 +172,34 @@ module Pod
     end
 
     describe 'sending the swift version up to trunk' do
-      it 'passes the value to trunk' do
+      before do
+        # This won't get called
         Command::Trunk::Push.any_instance.unstub(:update_master_repo)
+        # For faking the networking when sending
         Pod::Command::Trunk.any_instance.expects(:json).returns({})
-
         Pod::Command::Trunk.any_instance.expects(:auth_headers).returns({})
+      end
 
+      it 'passes the value to trunk' do
+        # Fakes for the network response
         response = mock
         response.expects(:headers).returns('location' => ['http://theinternet.com'])
+        response.expects(:status_code).returns(200)
 
         cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec --swift-version=1.1.2))
 
-        example = Pod::Specification.from_file('spec/fixtures/BananaLib.podspec')
-        example.attributes_hash[:pushed_with_swift_version] = '1.1.2'
+        # Using a blank podspec - JSON should include `"pushed_with_swift_version":"1.1.2"`
+        cmd.stubs(:spec).returns(Pod::Specification.new)
+
+        json = <<-JSON
+{"name":null,"pushed_with_swift_version":"1.1.2","platforms":{"osx":null,"ios":null,"tvos":null,"watchos":null}}
+        JSON
 
         cmd.stubs(:validate_podspec)
         cmd.stubs(:request_url)
 
         api_route = 'pods?allow_warnings=false'
-        cmd.expects(:request_path).with(:post, api_route, example.to_json, {}).returns(response)
+        cmd.expects(:request_path).with(:post, api_route, json, {}).returns(response)
         cmd.send(:push_to_trunk)
       end
     end


### PR DESCRIPTION
Allows the specs repo to have some information about the swift version of a pod, even though we are not adding a DSL attribute - https://github.com/CocoaPods/blog.cocoapods.org/pull/135