### PR TITLE
Properly display `pod trunk deprecate` command line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ##### Bug Fixes
 
+* Properly display `pod trunk deprecate` command line options  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#6486](https://github.com/CocoaPods/CocoaPods/issues/6486)
+
 * Add `--skip-import-validation` to skip linking a pod during lint.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#86](https://github.com/CocoaPods/cocoapods-trunk/pull/86)

--- a/lib/pod/command/trunk/deprecate.rb
+++ b/lib/pod/command/trunk/deprecate.rb
@@ -9,7 +9,7 @@ module Pod
           CLAide::Argument.new('NAME', true),
         ]
 
-        def options
+        def self.options
           [
             ['--in-favor-of=OTHER_NAME', 'The pod to deprecate this pod in favor of.'],
           ].concat(super)


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/6486

Before:

```
Usage:

    $ pod trunk deprecate NAME

      Deprecates a pod.

Options:

    --silent    Show nothing
    --verbose   Show more debugging information
    --no-ansi   Show output without ANSI codes
    --help      Show help banner of specified command
```

After:
```
Usage:

    $ pod trunk deprecate NAME

      Deprecates a pod.

Options:

    --in-favor-of=OTHER_NAME   The pod to deprecate this pod in favor of.
    --silent                   Show nothing
    --verbose                  Show more debugging information
    --no-ansi                  Show output without ANSI codes
    --help                     Show help banner of specified command
```