### PR TITLE
Adds a new command for renaming yourself on trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ##### Enhancements
 
-* None.  
+* Adds a `pod trunk me rename NAME` command so that you can change the display name on CocoaPods.org  
+  [Orta Therox](https://github.com/orta)  
+  [Ash Furrow](https://github.com/ashfurrow)  
+  [Ryan C. Payne](https://github.com/paynerc)  
+  [trunk.cocoapods.org#155](https://github.com/CocoaPods/trunk.cocoapods.org/issues/155)
 
 ##### Bug Fixes
 

--- a/lib/pod/command/trunk.rb
+++ b/lib/pod/command/trunk.rb
@@ -18,6 +18,7 @@ module Pod
       require 'pod/command/trunk/deprecate'
       require 'pod/command/trunk/info'
       require 'pod/command/trunk/me'
+      require 'pod/command/trunk/me_rename'
       require 'pod/command/trunk/push'
       require 'pod/command/trunk/register'
       require 'pod/command/trunk/remove_owner'

--- a/lib/pod/command/trunk/me_rename.rb
+++ b/lib/pod/command/trunk/me_rename.rb
@@ -1,0 +1,44 @@
+module Pod
+  class Command
+    class Trunk
+      # @CocoaPods 1.2.1+
+      #
+      class Rename < Me
+        self.summary = 'Rename your account'
+        self.description = <<-DESC
+              Updates your username for your Trunk account.
+
+              Examples:
+
+                  $ pod trunk me rename 'Eloy Durán'
+                  $ pod trunk me rename 'Orta Therox'
+        DESC
+
+        self.arguments = [
+          CLAide::Argument.new('NAME', true),
+        ]
+
+        def initialize(argv)
+          @name = argv.shift_argument
+          super
+        end
+
+        def validate!
+          super
+          unless @name
+            help! 'Please specify a name.'
+          end
+        end
+
+        def run
+          email = netrc['trunk.cocoapods.org'] && netrc['trunk.cocoapods.org'].login
+          body = { 'name' => @name, 'email' => email }.to_json
+          json(request_path(:post, 'sessions', body, auth_headers))
+        rescue REST::Error => e
+          raise Informative, 'There was an error re-naming your account on trunk: ' \
+                                 "#{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/spec/command/trunk/me_rename_spec.rb
+++ b/spec/command/trunk/me_rename_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module Pod
+  describe Command::Trunk::Register do
+    describe 'CLAide' do
+      it 'registers it self' do
+        Command.parse(%w[trunk me rename]).should.be.instance_of Command::Trunk::Rename
+      end
+    end
+
+    it 'should error if name is not supplied' do
+      command = Command.parse(%w[trunk me rename])
+      exception = lambda { command.validate! }.should.raise CLAide::Help
+      exception.message.should.include 'name'
+    end
+
+    it 'should error if name is not supplied' do
+      Netrc.any_instance.stubs(:[]).returns(nil)
+      command = Command.parse(%w[trunk me rename orta])
+      exception = lambda { command.validate! }.should.raise CLAide::Help
+      exception.message.should.include 'You need to register a session'
+    end
+
+    it 'should send an API call to update the user' do
+      url = 'https://trunk.cocoapods.org/api/v1/sessions'
+      WebMock::API.stub_request(:post, url).
+        with(:body => WebMock::API.hash_including('email' => 'kyle@cocoapods.org', 'name' => 'Kyle 2')).
+        to_return(:status => 200, :body => '{"token": "acct"}')
+
+      Netrc.any_instance.stubs(:[]).returns(stub('login' => 'kyle@cocoapods.org', 'password' => 'acct'))
+
+      command = Command.parse(['trunk', 'me', 'rename', 'Kyle 2'])
+      lambda { command.run }.should.not.raise
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/CocoaPods/trunk.cocoapods.org/issues/155

Overall the idea of re-registering with a new name to overwrite doesn't _really_ make sense. As discussed in https://github.com/CocoaPods/trunk.cocoapods.org/issues/155 I paired with @ashfurrow on adding a new command that allows you to _just_ rename yourself.

Also, thanks @paynerc 