### PR TITLE
Loosen netrc requirements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ PATH
   specs:
     cocoapods-trunk (1.2.0)
       nap (>= 0.8, < 2.0)
-      netrc (= 0.7.8)
+      netrc (~> 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -102,7 +102,7 @@ GEM
     multi_json (1.11.2)
     nanaimo (0.2.3)
     nap (1.1.0)
-    netrc (0.7.8)
+    netrc (0.11.0)
     notify (0.5.2)
     parser (2.3.0.7)
       ast (~> 2.2)
@@ -164,4 +164,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/cocoapods-trunk.gemspec
+++ b/cocoapods-trunk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'nap', '>= 0.8', '< 2.0'
-  spec.add_dependency 'netrc', '0.7.8'
+  spec.add_dependency 'netrc', '~> 0.11.0'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", '~> 10.0'
 


### PR DESCRIPTION
Currently `netrc` is hardwired to 0.7.8. This PR aims to loosen that requirement to avoid conflicts when cocoapods is being used with other gems sharing the same dependency.

It seems that Netrc interface didn't change much over years so I hope Travis tests can validate that cocoapods still work with netrc 0.11.0.