### PR TITLE
Rename an argument 'NAME' to 'YOUR_NAME'

### DIFF
--- a/lib/pod/command/trunk/register.rb
+++ b/lib/pod/command/trunk/register.rb
@@ -8,9 +8,9 @@ module Pod
         self.description = <<-DESC
               Register a new account, or create a new session.
 
-              If this is your first registration, both an `EMAIL` address and your
-              `NAME` are required. If you’ve already registered with trunk, you may
-              omit the `NAME` (unless you would like to change it).
+              If this is your first registration, both an `EMAIL` address and
+              `YOUR_NAME` are required. If you’ve already registered with trunk, you may
+              omit the `YOUR_NAME` (unless you would like to change it).
 
               It is recommended that you provide a description of the session, so
               that it will be easier to identify later on. For instance, when you
@@ -27,7 +27,7 @@ module Pod
 
         self.arguments = [
           CLAide::Argument.new('EMAIL', true),
-          CLAide::Argument.new('NAME',  false),
+          CLAide::Argument.new('YOUR_NAME', false),
         ]
 
         def self.options


### PR DESCRIPTION
I think most people read the first 2-3 lines from the usage:

```console
$ pod trunk register --help
Usage:

    $ pod trunk register EMAIL [NAME]
```

The `NAME` argument could mislead people to put their library name instead of their real name. This PR changes the argument name from `NAME` to `YOUR_NAME` for explicitness.

```diff
- $ pod trunk register EMAIL [NAME]
+ $ pod trunk register EMAIL [YOUR_NAME]
```