### PR TITLE
Remove `:pushed_with_swift_version` attribute hash

### DIFF
--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -33,7 +33,7 @@ module Pod
             ['--use-libraries', 'Linter uses static libraries to install the spec'],
             ['--use-modular-headers', 'Lint uses modular headers during installation'],
             ['--swift-version=VERSION', 'The SWIFT_VERSION that should be used to lint the spec. ' \
-             'This takes precedence over a .swift-version file.'],
+             'This takes precedence over a .swift-version file or swift_versions DSL.'],
             ['--skip-import-validation', 'Lint skips validating that the pod can be imported'],
             ['--skip-tests', 'Lint skips building and running tests during validation'],
           ].concat(super)
@@ -81,7 +81,6 @@ module Pod
         private
 
         def push_to_trunk
-          spec.attributes_hash[:pushed_with_swift_version] = @swift_version if @swift_version
           response = request_path(:post, "pods?allow_warnings=#{@allow_warnings}",
                                   spec.to_json, auth_headers)
           url = response.headers['location'].first

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -192,39 +192,6 @@ module Pod
       end
     end
 
-    describe 'sending the swift version up to trunk' do
-      before do
-        # This won't get called
-        Command::Trunk::Push.any_instance.unstub(:update_master_repo)
-        # For faking the networking when sending
-        Pod::Command::Trunk.any_instance.expects(:json).returns({})
-        Pod::Command::Trunk.any_instance.expects(:auth_headers).returns({})
-      end
-
-      it 'passes the value to trunk' do
-        # Fakes for the network response
-        response = mock
-        response.expects(:headers).returns('location' => ['http://theinternet.com'])
-        response.expects(:status_code).returns(200)
-
-        cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec --swift-version=1.1.2))
-
-        # Using a blank podspec - JSON should include `"pushed_with_swift_version":"1.1.2"`
-        cmd.stubs(:spec).returns(Pod::Specification.new)
-
-        json = <<-JSON
-{"name":null,"pushed_with_swift_version":"1.1.2","platforms":{"osx":null,"ios":null,"tvos":null,"watchos":null}}
-        JSON
-
-        cmd.stubs(:validate_podspec)
-        cmd.stubs(:request_url)
-
-        api_route = 'pods?allow_warnings=false'
-        cmd.expects(:request_path).with(:post, api_route, json, {}).returns(response)
-        cmd.send(:push_to_trunk)
-      end
-    end
-
     describe 'updating the master repo' do
       before do
         @cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec))


### PR DESCRIPTION
```bash
git rev-list --all | (
    while read revision; do
        git grep -F 'pushed_with_swift_version' $revision
    done
)
```

This was never used anywhere and now we always send the `swift_versions` up to trunk as part of the official podspec DSL.