### PR TITLE
Use trunk for podspec validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
    - 2.0.0-p647
    - 2.3.4
    - 2.4.1
+   - 2.6.3
 addons:
  code_climate:
    repo_token: 937468c2cbb0d7c0546b62d0fcbcba8a2a8b82714a64a52ffd0b951e71df626d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Update to get the master spec repo from `Source::Manager` for validation - effectively 
+  use the new CDN `TrunkSource` for podspec validation and not a hard-coded URL  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#132](https://github.com/CocoaPods/cocoapods-trunk/pull/132)
+  [CocoaPods#9112](https://github.com/CocoaPods/CocoaPods/issues/9112)
 
 ## 1.3.1 (2018-08-16)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,44 @@
 GIT
   remote: https://github.com/CocoaPods/CLAide.git
-  revision: 7f26d3d016efeea728ed0e608357e910d4c6e8f9
+  revision: b5ced9cc141df732e8027078543eb92fc6447567
   branch: master
   specs:
-    claide (1.0.2)
+    claide (1.0.3)
 
 GIT
   remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: a75a2e85e262c3c38d1a2fa9e0f5de01cc6a3368
+  revision: af83e4713771bc98dd7f903cc81c4fbc8866812c
   branch: master
   specs:
-    cocoapods (1.3.1)
+    cocoapods (1.8.0.beta.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.3.1)
-      cocoapods-deintegrate (>= 1.0.1, < 2.0)
-      cocoapods-downloader (>= 1.1.3, < 2.0)
+      cocoapods-core (= 1.8.0.beta.1)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (= 1.3.1)
+      cocoapods-trunk (>= 1.3.1, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
-      fourflusher (~> 2.0.1)
+      fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.1)
+      molinillo (~> 0.6.6)
       nap (~> 1.0)
-      ruby-macho (~> 1.1)
-      xcodeproj (>= 1.5.1, < 2.0)
+      ruby-macho (~> 1.4)
+      xcodeproj (>= 1.11.1, < 2.0)
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 77f5b2081bf347db73e5978737633e1943dc5f29
+  revision: 0a6dea961da236995dfde3c7927e4daaf2045820
   branch: master
   specs:
-    cocoapods-core (1.3.1)
+    cocoapods-core (1.8.0.beta.1)
       activesupport (>= 4.0.2, < 6)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.0)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
 
@@ -57,36 +59,43 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.5)
-    activesupport (4.2.9)
+    CFPropertyList (3.0.0)
+    activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    algoliasearch (1.26.1)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
     ast (2.2.0)
+    atomos (0.1.3)
     bacon (1.2.0)
-    cocoapods-deintegrate (1.0.1)
-    cocoapods-downloader (1.1.3)
+    cocoapods-deintegrate (1.0.4)
+    cocoapods-downloader (1.2.2)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.0.0)
+    cocoapods-stats (1.1.0)
     cocoapods-try (1.1.0)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     colored2 (3.1.2)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
     escape (0.0.4)
     ffi (1.9.10)
-    fourflusher (2.0.1)
+    fourflusher (2.3.1)
     fuzzy_match (2.0.4)
-    gh_inspector (1.0.3)
+    gh_inspector (1.1.3)
     hashdiff (0.3.4)
-    i18n (0.8.6)
+    httpclient (2.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     kicker (3.0.0)
       listen (~> 1.3.0)
       notify (~> 0.5.2)
@@ -95,14 +104,14 @@ GEM
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
-    minitest (5.10.3)
+    minitest (5.11.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    molinillo (0.6.3)
+    molinillo (0.6.6)
     multi_json (1.11.2)
-    nanaimo (0.2.3)
+    nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
     notify (0.5.2)
@@ -125,7 +134,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-macho (1.1.0)
+    ruby-macho (1.4.0)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     simplecov (0.9.2)
@@ -134,18 +143,19 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.0.3)
     webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    xcodeproj (1.5.1)
-      CFPropertyList (~> 2.3.3)
+    xcodeproj (1.12.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.3)
+      nanaimo (~> 0.2.6)
 
 PLATFORMS
   ruby
@@ -168,4 +178,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.0.3)
-    webmock (3.0.1)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -7,7 +7,7 @@ module Pod
         self.summary = 'Publish a podspec'
         self.description = <<-DESC
                 Publish the podspec at `PATH` to make it available to all users of
-                the ‘master’ spec-repo. If `PATH` is not provided, defaults to the
+                the ‘trunk’ spec-repo. If `PATH` is not provided, defaults to the
                 current directory.
 
                 Before pushing the podspec to cocoapods.org, this will perform a local
@@ -118,7 +118,7 @@ module Pod
         def validate_podspec
           UI.puts 'Validating podspec'.yellow
 
-          validator = Validator.new(spec, %w(https://github.com/CocoaPods/Specs.git))
+          validator = Validator.new(spec, [master_repo_url])
           validator.allow_warnings = @allow_warnings
           validator.use_frameworks = @use_frameworks
           if validator.respond_to?(:use_modular_headers=)
@@ -140,15 +140,26 @@ module Pod
         end
 
         def update_master_repo
-          sources_manager = if defined?(Pod::SourcesManager)
-                              Pod::SourcesManager
-                            else
-                              config.sources_manager
-                            end
           if sources_manager.master_repo_functional?
-            sources_manager.update('master')
+            sources_manager.update(master_repo_name)
           else
             Setup.invoke
+          end
+        end
+
+        def master_repo_name
+          sources_manager.master.first.name
+        end
+
+        def master_repo_url
+          sources_manager.master.first.url
+        end
+
+        def sources_manager
+          if defined?(Pod::SourcesManager)
+            Pod::SourcesManager
+          else
+            config.sources_manager
           end
         end
       end

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -104,6 +104,7 @@ module Pod
     describe 'validation' do
       before do
         Installer.any_instance.stubs(:aggregate_targets).returns([])
+        Installer.any_instance.stubs(:pod_targets).returns([])
 
         Validator.any_instance.stubs(:check_file_patterns)
         Validator.any_instance.stubs(:validate_url)
@@ -138,13 +139,13 @@ module Pod
 
       it 'validates specs as frameworks by default' do
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:ios, '8.0', true, []).once.returns(Podfile.new)
+          with(:ios, '8.0', true, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:osx, nil, true, []).once.returns(Podfile.new)
+          with(:osx, nil, true, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:tvos, nil, true, []).once.returns(Podfile.new)
+          with(:tvos, nil, true, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:watchos, nil, true, []).once.returns(Podfile.new)
+          with(:watchos, nil, true, [], nil).once.returns(Podfile.new)
 
         cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec))
         cmd.send(:validate_podspec)
@@ -152,13 +153,13 @@ module Pod
 
       it 'validates specs as libraries if requested' do
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:ios, nil, false, []).once.returns(Podfile.new)
+          with(:ios, nil, false, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:osx, nil, false, []).once.returns(Podfile.new)
+          with(:osx, nil, false, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:tvos, nil, false, []).once.returns(Podfile.new)
+          with(:tvos, nil, false, [], nil).once.returns(Podfile.new)
         Validator.any_instance.expects(:podfile_from_spec).
-          with(:watchos, nil, false, []).once.returns(Podfile.new)
+          with(:watchos, nil, false, [], nil).once.returns(Podfile.new)
 
         cmd = Command.parse(%w(trunk push spec/fixtures/BananaLib.podspec --use-libraries))
         cmd.send(:validate_podspec)

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -116,6 +116,8 @@ module Pod
         %i(prepare resolve_dependencies download_dependencies).each do |m|
           Installer.any_instance.stubs(m)
         end
+        Command::Trunk::Push.any_instance.stubs(:master_repo_url).
+          returns(Pod::TrunkSource::TRUNK_REPO_URL)
       end
 
       it 'passes the SWIFT_VERSION to the Validator' do
@@ -231,11 +233,13 @@ module Pod
         @cmd.stubs(:validate_podspec)
         @cmd.stubs(:push_to_trunk).returns([200, success_json])
         Command::Trunk::Push.any_instance.unstub(:update_master_repo)
+        Command::Trunk::Push.any_instance.stubs(:master_repo_name).
+          returns(Pod::TrunkSource::TRUNK_REPO_NAME)
       end
 
       it 'updates the master repo when it exists' do
         Config.instance.sources_manager.stubs(:master_repo_functional?).returns(true)
-        Config.instance.sources_manager.expects(:update).with('master').twice
+        Config.instance.sources_manager.expects(:update).with(Pod::TrunkSource::TRUNK_REPO_NAME).twice
 
         @cmd.run
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ require 'webmock'
 
 include WebMock::API
 WebMock.enable!
-WebMock.disable_net_connect!(:allow => 'codeclimate.com')
+WebMock.disable_net_connect!(:allow => ['codeclimate.com', 'cdn.cocoapods.org'])
 
 require 'cocoapods'
 


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/9112

This PR updates the plugin for the changes introduced in CocoaPods 1.8.0 by making CDN TrunkSource the default spec repo.