### PR TITLE
Use a more robust Trunk init when pushing

### DIFF
--- a/lib/pod/command/trunk/push.rb
+++ b/lib/pod/command/trunk/push.rb
@@ -140,11 +140,12 @@ module Pod
         end
 
         def update_master_repo
-          if sources_manager.master_repo_functional?
-            sources_manager.update(master_repo_name)
-          else
-            Setup.invoke
-          end
+          # more robust Trunk setup logic:
+          # - if Trunk exists, updates it
+          # - if Trunk doesn't exist, add it and update it
+          #
+          trunk = sources_manager.find_or_create_source_with_url(Pod::TrunkSource::TRUNK_REPO_URL)
+          sources_manager.update(trunk.name)
         end
 
         def master_repo_name

--- a/spec/command/trunk/push_spec.rb
+++ b/spec/command/trunk/push_spec.rb
@@ -239,16 +239,24 @@ module Pod
       end
 
       it 'updates the master repo when it exists' do
-        Config.instance.sources_manager.stubs(:master_repo_functional?).returns(true)
+        Config.instance.sources_manager.stubs(:source_with_url).
+          at_most(2).
+          returns(Pod::TrunkSource.new(Pod::TrunkSource::TRUNK_REPO_NAME)).
+          returns(Pod::TrunkSource.new(Pod::TrunkSource::TRUNK_REPO_NAME))
+
         Config.instance.sources_manager.expects(:update).with(Pod::TrunkSource::TRUNK_REPO_NAME).twice
+        Command::Repo::AddCDN.any_instance.expects(:run).never
 
         @cmd.run
       end
 
       it 'sets up the master repo when it does not exist' do
-        Config.instance.sources_manager.stubs(:master_repo_functional?).returns(false)
-        Config.instance.sources_manager.expects(:update).never
-        Command::Setup.any_instance.expects(:run).twice
+        Config.instance.sources_manager.stubs(:source_with_url).
+          at_most(3).
+          returns(nil).
+          returns(Pod::TrunkSource.new(Pod::TrunkSource::TRUNK_REPO_NAME))
+        Config.instance.sources_manager.expects(:update).with(Pod::TrunkSource::TRUNK_REPO_NAME).twice
+        Command::Repo::AddCDN.any_instance.expects(:run)
 
         @cmd.run
       end


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/9176

This new logic works with both the case when `TrunkSource` exists, and when it doesn't.